### PR TITLE
Change git summary to use hours for activity

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,23 +23,25 @@ usage: `git summary [--line]`
     --line      Outputs a summary of the repo by line
 ```
 
-Project:        Project name  
-Repo age:       Age of the oldest commit  
-Active days:    Sum of days with atleast one commit on them  
-Files:          Total amount of files in the project  
-Commits:        Total amount of commits in a project  
-Lines:          Total amount of lines in a project  
-Authors:        Total lines/commits of the author, author name, percentage contribution
+|||
+|---|---|
+|Project|Project name|  
+|Repo age|Age of the oldest commit|  
+|Activity|Sum of unique hours with commits in|  
+|Files|Total amount of files in the project|  
+|Commits|Total amount of commits in a project|  
+|Lines|Total amount of lines in a project|  
+|Authors|Total lines/commits of the author, author name, percentage contribution|
 
 Default summary
 ```
 $ git summary
  Project    : CCRPG
  Repo age   : 5 years ago
- active days: 46
- files      : 63
+ Activity   : 83 hours
+ Files      : 63
  Commits    : 192
- authors :
+ Authors :
    143  Alex                 74.5%
     23  Adam                 12.0%
     12  tvmanboy             6.2%
@@ -54,10 +56,10 @@ Summary by line
 $ git summary --line
  Project    : CCRPG
  Repo age   : 5 years ago
- active days: 46
- files      : 63
- lines   : 4197
- authors :
+ Activity   : 83 hours
+ Files      : 63
+ Lines   : 4197
+ Authors :
    3339 Alex           79.6%
     717 Adam           17.1%
      77 tvmanboy       1.8%

--- a/bin/git-summary
+++ b/bin/git-summary
@@ -60,29 +60,31 @@ line_count() {
 
 # Get the date of all commits
 date() {
-  git log --pretty='format: %ai' | cut -d ' ' -f 2
+  git log --pretty='format: %ai' | cut -d ' ' -f 2,3 | cut -d ':' -f 1
+}
+
+active_hours() {
+    date | sort -r | uniq | wc -l
 }
 
 # Sum all unqiue dates
-active_days() {
-  date | sort -r | uniq | awk '
-    { sum += 1 }
-    END { print sum }
-  '
+activity() {
+    total=$(active_hours)
+    echo "$total hours"
 }
 
 # Output
 echo " Project    : $project"
 echo " Repo age   : $age"
-echo " Active days: $(active_days)"
+echo " Activity   : $(activity)"
 echo " Files      : $files"
 
 if [ -n "$LINE_SUMMARY" ]; then
-    echo " Lines   : $(lines | wc -l)"
-    echo " Authors :"
+    echo " Lines      : $(lines | wc -l)"
+    echo " Authors    :"
     lines | sort | uniq -c | sort -rn | authors_percent
 else
     echo " Commits    : $commits"
-    echo " Authors :"
+    echo " Authors    :"
     git shortlog -n -s | authors_percent
 fi


### PR DESCRIPTION
Change git summary 'active days: n' out put to 'activity: n hours'
With hours being calculated based of of unique commits on hour timestamp