### PR TITLE
Git effort

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,16 @@ Download or clone the repo and add the path to the bin folder to `PATH`. (Or cop
 All commands are prefaced with git. e.g. `git root`
 - [git root](#git_root)
 - [git summary](#git_summary)
+- [git-effort])#git_effort)
 
 ---
 
 ### git root
 usage: `git root`
 
-Outputs the path to the root of the repo
+```
+                Outputs the path to the root of the repo
+```
 
 ### git summary
 usage: `git summary [--line]`
@@ -66,4 +69,16 @@ $ git summary --line
      50 Peguin666      1.2%
       9 Adam Hawley    0.2%
       5 Adam Plaskitt  0.1%
+```
+
+### git effort
+usage: `git effort [-h] [--above <int>] [--author <name>]`
+```
+                Lists: files, commits to the files, active hours on file.
+                Ordered by the target type: default commits
+    -h          Changes target type to active hours
+    --above <int>
+                Only lists entires with target type above int
+    --author <name>
+                Only registory commits and active hours from the provided author
 ```

--- a/bin/git-effort
+++ b/bin/git-effort
@@ -45,7 +45,7 @@ active_hours() {
 }
 
 
-files="$(git ls-files | HEAD -n10)" # Get files
+files="$(git ls-files)" # Get files
 for file in $files
 do
     # Add row to data

--- a/bin/git-effort
+++ b/bin/git-effort
@@ -10,16 +10,22 @@ dates() {
 
 # Get the commits for a file
 commits() {
-    dates | wc -l
+    dates | awk '
+    { sum += 1 }
+    END { print sum }
+  '
 }
 
 # Get the active hours for a file
 active_hours() {
-    dates | uniq | wc -l
+    dates | uniq | awk '
+    { sum += 1 }
+    END { print sum }
+  '
 }
 
 
-files="$(git ls-files | HEAD -n2)" # Get files
+files="$(git ls-files | HEAD)" # Get files
 for file in $files
 do
     # Add row to data

--- a/bin/git-effort
+++ b/bin/git-effort
@@ -1,6 +1,26 @@
 #!/usr/bin/env bash
 
-data=()
+ABOVE=0
+while test $# -gt 0;
+do
+    case "$1" in
+        --above)
+            shift
+            if test $# -gt 0;
+            then
+                ABOVE=$1
+            else
+                echo "No limit set"
+                exit
+            fi
+            shift
+            ;;
+        *)
+        break
+        ::
+    esac
+done
+
 max=0
 
 # Get the dates related to a file
@@ -25,7 +45,7 @@ active_hours() {
 }
 
 
-files="$(git ls-files | HEAD)" # Get files
+files="$(git ls-files | HEAD -n10)" # Get files
 for file in $files
 do
     # Add row to data
@@ -42,5 +62,9 @@ printf "  %-${len}s %-10s %s\n" 'path' 'commits' 'active hours'
 
 for file in $files
 do
-    printf "  %-${len}s %-10s %s\n" ${file} $(commits) $(active_hours)
+    total_commits=$(commits)
+    if [ $total_commits -ge $ABOVE ]
+    then
+        printf "  %-${len}s %-10s %s\n" ${file} ${total_commits} $(active_hours)
+    fi
 done

--- a/bin/git-effort
+++ b/bin/git-effort
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+data=()
+max=0
+
+# Get the dates related to a file
+dates() {
+    git log --pretty='format: %ad' $file | sed 's/ ... //g' | sed 's/:..:..//g' | sed 's/ +.*//g'
+}
+
+# Get the commits for a file
+commits() {
+    dates | wc -l
+}
+
+# Get the active hours for a file
+active_hours() {
+    dates | uniq | wc -l
+}
+
+
+files="$(git ls-files | HEAD -n2)" # Get files
+for file in $files
+do
+    # Add row to data
+    if [ ${#file} -ge $max ]
+    then
+        max=${#file}
+    fi
+done
+
+# Get the length of the max row plus 5
+len=$((max + 5))
+# Output
+printf "  %-${len}s %-10s %s\n" 'path' 'commits' 'active hours'
+
+for file in $files
+do
+    printf "  %-${len}s %-10s %s\n" ${file} $(commits) $(active_hours)
+done

--- a/bin/git-effort
+++ b/bin/git-effort
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 
 ABOVE=0
+H=0
+AUTHOR=""
 while test $# -gt 0;
 do
     case "$1" in
@@ -15,17 +17,30 @@ do
             fi
             shift
             ;;
+        -h)
+           H=1
+           shift
+           ;;
+        --author)
+            shift
+            if test $# -gt 0;
+            then
+                AUTHOR=$1
+            else
+                echo "No author provided"
+                exit
+            fi
+            shift
+            ;;
         *)
         break
         ::
     esac
 done
 
-max=0
-
 # Get the dates related to a file
 dates() {
-    git log --pretty='format: %ad' $file | sed 's/ ... //g' | sed 's/:..:..//g' | sed 's/ +.*//g'
+    git log --author=$AUTHOR --pretty='format: %ad' $file 2>/dev/null | sed 's/ ... //g' | sed 's/:..:..//g' | sed 's/ +.*//g'
 }
 
 # Get the commits for a file
@@ -44,15 +59,29 @@ active_hours() {
   '
 }
 
-
+tmpfile=$(mktemp /tmp/abc-script.XXXXXX)
+max=0
 files="$(git ls-files)" # Get files
 for file in $files
 do
-    # Add row to data
-    if [ ${#file} -ge $max ]
+    total_commits=$(commits)
+    total_hours=$(active_hours)
+
+    limit=$total_commits
+    if [[ $H -gt 0 ]]
     then
-        max=${#file}
+        limit=$total_hours
     fi
+
+    if [[ $limit -gt $ABOVE ]]
+    then
+        # Add row to data
+        if [[ ${#file} -ge $max ]]
+        then
+            max=${#file}
+        fi
+        printf "${file};${total_commits};${total_hours}\n" >> $tmpfile
+    fi   
 done
 
 # Get the length of the max row plus 5
@@ -60,11 +89,22 @@ len=$((max + 5))
 # Output
 printf "  %-${len}s %-10s %s\n" 'path' 'commits' 'active hours'
 
-for file in $files
-do
-    total_commits=$(commits)
-    if [ $total_commits -ge $ABOVE ]
-    then
-        printf "  %-${len}s %-10s %s\n" ${file} ${total_commits} $(active_hours)
-    fi
-done
+
+
+#if [[ $limit -gt $ABOVE ]]
+#    then
+#        printf "  %-${len}s %-10s %s\n" ${file} ${total_commits} ${total_hours}
+#    fi
+
+if [[ $H -gt 0 ]]
+then
+    # hours
+    sort --field-separator=';' -k3nr -k2nr -o $tmpfile $tmpfile
+else
+    # commits
+    sort --field-separator=';' -k2nr -k3nr -o $tmpfile $tmpfile
+fi
+
+cat $tmpfile
+
+rm "$tmpfile"

--- a/bin/git-effort
+++ b/bin/git-effort
@@ -60,6 +60,7 @@ active_hours() {
 }
 
 tmpfile=$(mktemp /tmp/abc-script.XXXXXX)
+tmpout=$(mktemp /tmp/abc-script.XXXXXX)
 max=0
 files="$(git ls-files)" # Get files
 for file in $files
@@ -75,26 +76,10 @@ do
 
     if [[ $limit -gt $ABOVE ]]
     then
-        # Add row to data
-        if [[ ${#file} -ge $max ]]
-        then
-            max=${#file}
-        fi
-        printf "${file};${total_commits};${total_hours}\n" >> $tmpfile
+        printf "${file} ; ${total_commits} ; ${total_hours}\n" >> $tmpfile
     fi   
 done
 
-# Get the length of the max row plus 5
-len=$((max + 5))
-# Output
-printf "  %-${len}s %-10s %s\n" 'path' 'commits' 'active hours'
-
-
-
-#if [[ $limit -gt $ABOVE ]]
-#    then
-#        printf "  %-${len}s %-10s %s\n" ${file} ${total_commits} ${total_hours}
-#    fi
 
 if [[ $H -gt 0 ]]
 then
@@ -105,6 +90,8 @@ else
     sort --field-separator=';' -k2nr -k3nr -o $tmpfile $tmpfile
 fi
 
-cat $tmpfile
+echo -e "path ; commits ; active hours" | cat - $tmpfile > $tmpout
 
-rm "$tmpfile"
+cat $tmpout | column -t -s";"
+
+rm "$tmpfile" "$tmpout"

--- a/bin/git-summary
+++ b/bin/git-summary
@@ -22,10 +22,16 @@ project=${PWD##*/}
 age="$(git log --reverse --format="%ar" | head -n 1)"
 
 # Get commit count
-commits="$(git log --oneline | wc -l)"
+commits="$(git log --oneline | awk '
+    { sum += 1 }
+    END { print sum }
+  ')"
 
 # Get total files
-files="$(git ls-files | wc -l)"
+files="$(git ls-files | awk '
+    { sum += 1 }
+    END { print sum }
+  ')"
 
 # Format authors with percent after
 authors_percent() {
@@ -55,7 +61,10 @@ lines() {
 
 # Count the lines
 line_count() {
-    lines | wc -l
+    lines | awk '
+    { sum += 1 }
+    END { print sum }
+  '
 }
 
 # Get the date of all commits
@@ -80,7 +89,7 @@ echo " Activity   : $(activity)"
 echo " Files      : $files"
 
 if [ -n "$LINE_SUMMARY" ]; then
-    echo " Lines      : $(lines | wc -l)"
+    echo " Lines      : $(line_count)"
     echo " Authors    :"
     lines | sort | uniq -c | sort -rn | authors_percent
 else


### PR DESCRIPTION
Adds the git-effort command.

### git effort
usage: `git effort [-h] [--above <int>] [--author <name>]`
```
                Lists: files, commits to the files, active hours on file.
                Ordered by the target type: default commits
    -h          Changes target type to active hours
    --above <int>
                Only lists entires with target type above int
    --author <name>
                Only registry commits and active hours from the provided author
```